### PR TITLE
Make tile flip speed configurable

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+window.WORDLE_CONFIG = {
+  // Duration for the tile flip animation and delay between tiles (ms)
+  flipMs: 600,
+};

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
   </dialog>
 
   <script src="words.js"></script>
+  <script src="config.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,8 @@
 
 (() => {
   const ROWS = 6, COLS = 5;
+  const FLIP_MS = (window.WORDLE_CONFIG && window.WORDLE_CONFIG.flipMs) || 300;
+  document.documentElement.style.setProperty('--flip-duration', FLIP_MS + 'ms');
   const boardEl = document.getElementById('board');
   const kbRows = [
     "QWERTYUIOP",
@@ -280,7 +282,7 @@
           if (i === tiles.length - 1) {
             resolve();
           }
-        }, i * 300);
+        }, i * FLIP_MS);
       });
     });
   }

--- a/style.css
+++ b/style.css
@@ -95,7 +95,7 @@ main{
 .tile.reveal{
   color:#fff;
   transform: rotateX(0);
-  animation: flip 500ms ease forwards;
+  animation: flip var(--flip-duration, 500ms) ease forwards;
 }
 @keyframes flip{
   0%{ transform: rotateX(0deg); }


### PR DESCRIPTION
## Summary
- Slow down tile reveal and allow configuring the flip timing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a202e450a4832287e7a769f385234f