### PR TITLE
feat: add console variable to reveal answer for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ Word lists are bundled in `words.js`, generated from uploaded word files.
 
 ## License
 This project is open source under the MIT License.
+
+## Debugging
+To reveal the current target word during testing, open the browser's developer console and assign any value to the global `REVEAL_ANSWER` variable:
+
+```js
+REVEAL_ANSWER = true; // logs the secret word to the console
+```

--- a/script.js
+++ b/script.js
@@ -328,4 +328,12 @@
 
   // Expose for debugging
   window.__wordle = { get answer(){return answer}, set answer(v){answer=v} };
+
+  // Assigning any value to REVEAL_ANSWER in the console prints the current answer.
+  Object.defineProperty(window, 'REVEAL_ANSWER', {
+    configurable: true,
+    set(v){
+      console.log(`Wordle answer: ${answer.toUpperCase()}`);
+    }
+  });
 })();


### PR DESCRIPTION
## Summary
- add `REVEAL_ANSWER` global to log the current wordle answer when assigned in the dev console
- document debug variable in README

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60568c1b883228e1ab990394c1785