### PR TITLE
Add hint feature with configurable tooltip

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,6 @@
 window.WORDLE_CONFIG = {
   // Duration for the tile flip animation and delay between tiles (ms)
   flipMs: 600,
+  // Duration the hint tooltip is visible (ms)
+  hintMs: 2000,
 };

--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@
         <input id="hardMode" type="checkbox">
         <span>Hard Mode</span>
       </label>
+      <div class="hint-container">
+        <button id="hintBtn" class="ghost" title="Show a hint">💡</button>
+        <div id="hintTooltip" class="hint-tooltip" role="tooltip"></div>
+      </div>
       <button id="newGameBtn" class="ghost" title="Start a new game">↻</button>
     </div>
   </header>

--- a/style.css
+++ b/style.css
@@ -44,6 +44,22 @@ body{
 .controls{display:flex; gap:10px; align-items:center}
 .toggle{display:flex; align-items:center; gap:6px; font-size:14px; color:var(--accent)}
 .toggle input{accent-color:var(--present); width:18px; height:18px}
+.hint-container{position:relative}
+.hint-tooltip{
+  position:absolute;
+  bottom:calc(100% + 4px);
+  left:50%;
+  transform:translateX(-50%);
+  background:#000;
+  color:#fff;
+  padding:4px 8px;
+  border-radius:4px;
+  font-size:14px;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .2s;
+}
+.hint-tooltip.show{opacity:1}
 button{
   border:0; background:var(--key-bg); color:var(--key-text);
   padding:10px 12px; border-radius:6px; font-weight:600;


### PR DESCRIPTION
## Summary
- Add light bulb hint button that displays a temporary tooltip
- Implement hint algorithm respecting hard-mode clues and avoiding repeated guesses
- Make hint display duration configurable via `hintMs`

## Testing
- `node -c script.js`
- `node -c config.js`


------
https://chatgpt.com/codex/tasks/task_e_68a75d30ac488322813135b9a11ea620