### PR TITLE
fix: ensure hint button works on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -88,8 +88,7 @@
     if (/^[A-Z]$/.test(k)) handleKey(k);
   });
 
-  hintBtn.addEventListener('click', () => {
-    setTimeout(() => hintBtn.blur(), 0);
+  function showHint(){
     if (finished) return;
     if (hintTooltip.classList.contains('show')) return;
     const word = generateHintWord();
@@ -101,6 +100,13 @@
     hintTooltip.classList.add('show');
     clearTimeout(hintHideTimeout);
     hintHideTimeout = setTimeout(() => hintTooltip.classList.remove('show'), HINT_MS);
+    setTimeout(() => hintBtn.blur(), 0);
+  }
+
+  hintBtn.addEventListener('click', showHint);
+  hintBtn.addEventListener('touchstart', (e) => {
+    e.preventDefault();
+    showHint();
   });
 
   newGameBtn.addEventListener('click', () => resetGame());


### PR DESCRIPTION
## Summary
- Handle mobile `touchstart` for hint button and centralize hint logic
- Blur hint button after displaying to remove focus styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cb776a308322b113bcb53ef91770