### PR TITLE
Fix tile flip animations after invalid guesses

### DIFF
--- a/script.js
+++ b/script.js
@@ -345,6 +345,8 @@
     // trigger reflow
     void rowEl.offsetWidth;
     rowEl.classList.add('shake');
+    // Remove the shake class after the animation so future flips work
+    rowEl.addEventListener('animationend', () => rowEl.classList.remove('shake'), { once: true });
   }
 
   let toastTimeout;


### PR DESCRIPTION
## Summary
- remove `shake` class after animation completes to restore flip animations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb0ce01248322bebbb1e005aff50f